### PR TITLE
checker: change ttl/hoplimit for tun checks

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+keepalived (1:1.2.21-ttl) bionic; urgency=medium
+
+  * set ttl=2 for tunneled checks
+
+ -- Vadim Fedorenko <junk@yandex-team.ru>  Mon, 20 Jan 2020 16:05:43 +0300
+
 keepalived (1:1.2.21-ext-logging) bionic; urgency=medium
 
   * add VS information in check events

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -923,6 +923,10 @@ http_connect_thread(thread_t * thread)
 		return 0;
 	}
 
+	if (checker->vs->loadbalancing_kind == IP_VS_CONN_F_TUNNEL) {
+		status = tcp_ttl_setup(fd, co);
+	}
+
 	status = tcp_bind_connect(fd, co);
 
 	/* handle tcp connection status & register check worker thread */

--- a/keepalived/check/check_tcp.c
+++ b/keepalived/check/check_tcp.c
@@ -218,6 +218,10 @@ tcp_connect_thread(thread_t * thread)
 		return 0;
 	}
 
+	if (checker->vs->loadbalancing_kind == IP_VS_CONN_F_TUNNEL) {
+		status = tcp_ttl_setup(fd, co);
+	}
+
 	status = tcp_bind_connect(fd, co);
 
 	/* handle tcp connection status & register check worker thread */

--- a/keepalived/core/layer4.c
+++ b/keepalived/core/layer4.c
@@ -26,6 +26,30 @@
 #include "logger.h"
 
 enum connect_result
+tcp_ttl_setup(int fd, conn_opts_t *co)
+{
+	int ttl = 2;
+	int ret;
+
+	switch (((struct sockaddr *) &co->dst)->sa_family) {
+		case AF_INET:
+			ret = setsockopt (fd, SOL_IP, IP_TTL, &ttl, sizeof (ttl));
+			break;
+		case AF_INET6:
+			ret = setsockopt (fd, SOL_IPV6, IPV6_UNICAST_HOPS, &ttl, sizeof (ttl));
+			break;
+		default:
+			ret = 0;
+			break;
+	}
+	if (ret < 0) {
+		log_message(LOG_ERR, "Error setting TTL %d to socket: %s", ttl, strerror(errno));
+		return connect_error;
+	}
+	return connect_success;
+}
+
+enum connect_result
 tcp_bind_connect(int fd, conn_opts_t *co)
 {
 	struct linger li = { 0 };

--- a/keepalived/include/layer4.h
+++ b/keepalived/include/layer4.h
@@ -45,6 +45,9 @@ enum connect_result {
 
 /* Prototypes defs */
 extern enum connect_result
+tcp_ttl_setup(int fd, conn_opts_t *co);
+
+extern enum connect_result
  tcp_bind_connect(int, conn_opts_t *);
 
 extern enum connect_result


### PR DESCRIPTION
This patch prevents false positive checks for tunneled reals
when VIP is not configured on real and ip_forward is enabled
by limiting max hop count on packets inside the tunnel